### PR TITLE
fix variables web-font include

### DIFF
--- a/cosmo/_variables.scss
+++ b/cosmo/_variables.scss
@@ -39,7 +39,7 @@ $link-hover-color:      darken($link-color, 15%) !default;
 //
 //## Font, line-height, and color for body text, headings, and more.
 
-$web-font: ""//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700""
+$web-font: "//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700";
 
 $font-family-sans-serif:  "Source Sans Pro", Calibri, Candara, Arial, sans-serif !default;
 $font-family-serif:       Georgia, "Times New Roman", Times, serif !default;


### PR DESCRIPTION
This change removes extra double-quotes and adds a semi-colon to ensure valid SCSS.
